### PR TITLE
Updated Minecraft version

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "version": "0.3.9",
-  "mcVersion": "1.16.4",
+  "mcVersion": "1.16.5",
   
   "changelog": [
     "Added rotation setting to AntiAutoAnvil",


### PR DESCRIPTION
Now meteor compatible with `1.16.5`! No thanks needed